### PR TITLE
remove API from dependencies and include API base module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     // https://mvnrepository.com/artifact/org.jetbrains/annotations
     compileOnly group: 'org.jetbrains', name: 'annotations', version: '19.0.0'
     modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
-    modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+    modImplementation include("net.fabricmc.fabric-api:fabric-api-base:${project.fabric_base_version}")
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ loader_version=+
 fabric_version=0.15.0+build.379-1.16
 fabric_base_version=0.1+
 # Mod Properties
-mod_version=0.2.4
+mod_version=0.2.5
 maven_group=net.devtech
 archives_base_name=arrp
 # Dependencies

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,11 +2,12 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.16-pre2
-yarn_mappings=1.16-pre2+build.18
-loader_version=0.8.7+build.201
+minecraft_version=20w29a
+yarn_mappings=20w29a+build.9
+loader_version=+
 #Fabric api
-fabric_version=0.11.7+build.356-1.16
+fabric_version=0.15.0+build.379-1.16
+fabric_base_version=0.1+
 # Mod Properties
 mod_version=0.2.4
 maven_group=net.devtech

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,7 +23,6 @@
   ],
   "depends": {
     "fabricloader": ">=0.8.8+build.202",
-    "fabric": "*",
     "minecraft": ">=1.16.1"
   }
 }


### PR DESCRIPTION
This pull request fixes incompatibility between Fabric API and newer Minecraft versions by removing the entirety of Fabric API from dependencies except its base module for its events. It also changes loader version to latest due to incompatibility between the required version in fabric.mod.json and that included in build.gradle. (Any version greater than 0.8.8 should work, but I chose the latest.)