### PR TITLE
Loot table generation improvements

### DIFF
--- a/src/main/java/net/devtech/arrp/json/loot/JCondition.java
+++ b/src/main/java/net/devtech/arrp/json/loot/JCondition.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Type;
 
 import com.google.gson.*;
 import net.devtech.arrp.impl.RuntimeResourcePackImpl;
+import net.minecraft.util.Identifier;
 
 public class JCondition implements Cloneable {
 	private JsonObject parameters = new JsonObject();
@@ -46,6 +47,10 @@ public class JCondition implements Cloneable {
 
 	public JCondition parameter(String key, Character value) {
 		return parameter(key, new JsonPrimitive(value));
+	}
+
+	public JCondition parameter(String key, Identifier value) {
+		return parameter(key, value.toString());
 	}
 
 	/**

--- a/src/main/java/net/devtech/arrp/json/loot/JCondition.java
+++ b/src/main/java/net/devtech/arrp/json/loot/JCondition.java
@@ -2,11 +2,7 @@ package net.devtech.arrp.json.loot;
 
 import java.lang.reflect.Type;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonSerializationContext;
-import com.google.gson.JsonSerializer;
+import com.google.gson.*;
 import net.devtech.arrp.impl.RuntimeResourcePackImpl;
 
 public class JCondition implements Cloneable {
@@ -17,13 +13,39 @@ public class JCondition implements Cloneable {
 	 * @see JLootTable#predicate(String)
 	 */
 	public JCondition(String condition) {
+		condition(condition);
+	}
+
+	public JCondition condition(String condition) {
 		this.parameters.addProperty("condition", condition);
+		return this;
 	}
 
 	public JCondition set(JsonObject parameters) {
 		parameters.addProperty("condition",this.parameters.get("condition").getAsString());
 		this.parameters = parameters;
 		return this;
+	}
+
+	public JCondition addParameter(String key, JsonElement value) {
+		this.parameters.add(key, value);
+		return this;
+	}
+
+	public JCondition addParameter(String key, String value) {
+		return addParameter(key, new JsonPrimitive(value));
+	}
+
+	public JCondition addParameter(String key, Number value) {
+		return addParameter(key, new JsonPrimitive(value));
+	}
+
+	public JCondition addParameter(String key, Boolean value) {
+		return addParameter(key, new JsonPrimitive(value));
+	}
+
+	public JCondition addParameter(String key, Character value) {
+		return addParameter(key, new JsonPrimitive(value));
 	}
 
 	/**

--- a/src/main/java/net/devtech/arrp/json/loot/JCondition.java
+++ b/src/main/java/net/devtech/arrp/json/loot/JCondition.java
@@ -27,25 +27,25 @@ public class JCondition implements Cloneable {
 		return this;
 	}
 
-	public JCondition addParameter(String key, JsonElement value) {
+	public JCondition parameter(String key, JsonElement value) {
 		this.parameters.add(key, value);
 		return this;
 	}
 
-	public JCondition addParameter(String key, String value) {
-		return addParameter(key, new JsonPrimitive(value));
+	public JCondition parameter(String key, String value) {
+		return parameter(key, new JsonPrimitive(value));
 	}
 
-	public JCondition addParameter(String key, Number value) {
-		return addParameter(key, new JsonPrimitive(value));
+	public JCondition parameter(String key, Number value) {
+		return parameter(key, new JsonPrimitive(value));
 	}
 
-	public JCondition addParameter(String key, Boolean value) {
-		return addParameter(key, new JsonPrimitive(value));
+	public JCondition parameter(String key, Boolean value) {
+		return parameter(key, new JsonPrimitive(value));
 	}
 
-	public JCondition addParameter(String key, Character value) {
-		return addParameter(key, new JsonPrimitive(value));
+	public JCondition parameter(String key, Character value) {
+		return parameter(key, new JsonPrimitive(value));
 	}
 
 	/**

--- a/src/main/java/net/devtech/arrp/json/loot/JEntry.java
+++ b/src/main/java/net/devtech/arrp/json/loot/JEntry.java
@@ -31,20 +31,20 @@ public class JEntry implements Cloneable {
 	}
 
 	public JEntry child(JEntry child) {
-	    if (this == child) {
-	        throw new IllegalArgumentException("Can't add entry as its own child!");
-        }
-        if (this.children == null) {
-            this.children = new ArrayList<>();
-        }
-        this.children.add(child);
-        return this;
-    }
+		if (this == child) {
+			throw new IllegalArgumentException("Can't add entry as its own child!");
+		}
+		if (this.children == null) {
+			this.children = new ArrayList<>();
+		}
+		this.children.add(child);
+		return this;
+	}
 
-    /**
-     * @deprecated unintuitive to use
-     * @see JEntry#child(JEntry)
-     */
+	/**
+	 * @deprecated unintuitive to use
+	 * @see JEntry#child(JEntry)
+	 */
 	@Deprecated
 	public JEntry child(String child) {
 		return child(RuntimeResourcePackImpl.GSON.fromJson(child, JEntry.class));
@@ -63,13 +63,13 @@ public class JEntry implements Cloneable {
 		return this;
 	}
 
-    public JEntry condition(JCondition condition) {
-        if(this.conditions == null) {
-            this.conditions = new ArrayList<>();
-        }
-        this.conditions.add(condition);
-        return this;
-    }
+	public JEntry condition(JCondition condition) {
+		if(this.conditions == null) {
+			this.conditions = new ArrayList<>();
+		}
+		this.conditions.add(condition);
+		return this;
+	}
 
 	public JEntry weight(Integer weight) {
 		this.weight = weight;

--- a/src/main/java/net/devtech/arrp/json/loot/JEntry.java
+++ b/src/main/java/net/devtech/arrp/json/loot/JEntry.java
@@ -63,6 +63,10 @@ public class JEntry implements Cloneable {
 		return this;
 	}
 
+	public JEntry function(String function) {
+	    return function(JLootTable.function(function));
+    }
+
 	public JEntry condition(JCondition condition) {
 		if(this.conditions == null) {
 			this.conditions = new ArrayList<>();
@@ -70,6 +74,10 @@ public class JEntry implements Cloneable {
 		this.conditions.add(condition);
 		return this;
 	}
+
+	public JEntry condition(String condition) {
+	    return condition(JLootTable.predicate(condition));
+    }
 
 	public JEntry weight(Integer weight) {
 		this.weight = weight;

--- a/src/main/java/net/devtech/arrp/json/loot/JEntry.java
+++ b/src/main/java/net/devtech/arrp/json/loot/JEntry.java
@@ -1,25 +1,19 @@
 package net.devtech.arrp.json.loot;
 
+import net.devtech.arrp.impl.RuntimeResourcePackImpl;
+
 import java.util.ArrayList;
 import java.util.List;
 
 public class JEntry implements Cloneable {
 	private String type;
 	private String name;
-	private List<String> children;
+	private List<JEntry> children;
 	private Boolean expand;
 	private List<JFunction> functions;
-	private List<JCondition> condition;
+	private List<JCondition> conditions;
 	private Integer weight;
 	private Integer quality;
-
-	public JEntry condition(JCondition condition) {
-		if(this.condition == null) {
-			this.condition = new ArrayList<>();
-		}
-		this.condition.add(condition);
-		return this;
-	}
 
 	/**
 	 * @see JLootTable#entry()
@@ -36,12 +30,24 @@ public class JEntry implements Cloneable {
 		return this;
 	}
 
+	public JEntry child(JEntry child) {
+	    if (this == child) {
+	        throw new IllegalArgumentException("Can't add entry as its own child!");
+        }
+        if (this.children == null) {
+            this.children = new ArrayList<>();
+        }
+        this.children.add(child);
+        return this;
+    }
+
+    /**
+     * @deprecated unintuitive to use
+     * @see JEntry#child(JEntry)
+     */
+	@Deprecated
 	public JEntry child(String child) {
-		if (this.children == null) {
-			this.children = new ArrayList<>();
-		}
-		this.children.add(child);
-		return this;
+		return child(RuntimeResourcePackImpl.GSON.fromJson(child, JEntry.class));
 	}
 
 	public JEntry expand(Boolean expand) {
@@ -56,6 +62,14 @@ public class JEntry implements Cloneable {
 		this.functions.add(function);
 		return this;
 	}
+
+    public JEntry condition(JCondition condition) {
+        if(this.conditions == null) {
+            this.conditions = new ArrayList<>();
+        }
+        this.conditions.add(condition);
+        return this;
+    }
 
 	public JEntry weight(Integer weight) {
 		this.weight = weight;

--- a/src/main/java/net/devtech/arrp/json/loot/JEntry.java
+++ b/src/main/java/net/devtech/arrp/json/loot/JEntry.java
@@ -76,8 +76,8 @@ public class JEntry implements Cloneable {
 	}
 
 	public JEntry condition(String condition) {
-	    return condition(JLootTable.predicate(condition));
-    }
+		return condition(JLootTable.predicate(condition));
+	}
 
 	public JEntry weight(Integer weight) {
 		this.weight = weight;

--- a/src/main/java/net/devtech/arrp/json/loot/JFunction.java
+++ b/src/main/java/net/devtech/arrp/json/loot/JFunction.java
@@ -59,14 +59,14 @@ public class JFunction implements Cloneable {
 		return this;
 	}
 
-    /**
-     * @deprecated unintuitive name
-     * @see JFunction#condition(JCondition)
-     */
+	/**
+	 * @deprecated unintuitive name
+	 * @see JFunction#condition(JCondition)
+	 */
 	@Deprecated
 	public JFunction add(JCondition condition) {
-	    return condition(condition);
-    }
+		return condition(condition);
+	}
 
 	@Override
 	public JFunction clone() {

--- a/src/main/java/net/devtech/arrp/json/loot/JFunction.java
+++ b/src/main/java/net/devtech/arrp/json/loot/JFunction.java
@@ -1,28 +1,60 @@
 package net.devtech.arrp.json.loot;
 
+import com.google.gson.*;
+import net.minecraft.util.Identifier;
+
 import java.lang.reflect.Type;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonSerializationContext;
-import com.google.gson.JsonSerializer;
 
 public class JFunction implements Cloneable {
 	private final List<JCondition> conditions = new ArrayList<>();
-	private Map<String, Object> properties = new HashMap<>();
+	private JsonObject properties = new JsonObject();
 
 	/**
 	 * @see JLootTable#function(String)
 	 */
 	public JFunction(String function) {
-		this.properties.put("function", function);
+		function(function);
 	}
 
-	public JFunction add(JCondition condition) {
+	public JFunction function(String function) {
+		this.properties.addProperty("function", function);
+		return this;
+	}
+
+	public JFunction set(JsonObject properties) {
+		properties.addProperty("function",this.properties.get("function").getAsString());
+		this.properties = properties;
+		return this;
+	}
+
+	public JFunction parameter(String key, JsonElement value) {
+		this.properties.add(key, value);
+		return this;
+	}
+
+	public JFunction parameter(String key, String value) {
+		return parameter(key, new JsonPrimitive(value));
+	}
+
+	public JFunction parameter(String key, Number value) {
+		return parameter(key, new JsonPrimitive(value));
+	}
+
+	public JFunction parameter(String key, Boolean value) {
+		return parameter(key, new JsonPrimitive(value));
+	}
+
+	public JFunction parameter(String key, Identifier value) {
+		return parameter(key, value.toString());
+	}
+
+	public JFunction parameter(String key, Character value) {
+		return parameter(key, new JsonPrimitive(value));
+	}
+
+	public JFunction condition(JCondition condition) {
 		this.conditions.add(condition);
 		return this;
 	}
@@ -39,11 +71,10 @@ public class JFunction implements Cloneable {
 	public static class Serializer implements JsonSerializer<JFunction> {
 		@Override
 		public JsonElement serialize(JFunction src, Type typeOfSrc, JsonSerializationContext context) {
-			JsonObject element = context.serialize(src.properties).getAsJsonObject();
 			if (!src.conditions.isEmpty()) {
-				element.add("conditions", context.serialize(src.conditions));
+				src.properties.add("conditions", context.serialize(src.conditions));
 			}
-			return element;
+			return src.properties;
 		}
 	}
 }

--- a/src/main/java/net/devtech/arrp/json/loot/JFunction.java
+++ b/src/main/java/net/devtech/arrp/json/loot/JFunction.java
@@ -59,6 +59,15 @@ public class JFunction implements Cloneable {
 		return this;
 	}
 
+    /**
+     * @deprecated unintuitive name
+     * @see JFunction#condition(JCondition)
+     */
+	@Deprecated
+	public JFunction add(JCondition condition) {
+	    return condition(condition);
+    }
+
 	@Override
 	public JFunction clone() {
 		try {


### PR DESCRIPTION
- Added `JCondition#parameter(String, JsonElement)`, along with primitive value overloads
  - These make `JCondition` a bit less awkward to use (since you no longer have to create a `JsonObject` beforehand)
  - Also added `JCondition#condition(String)`. It's exactly what you think it is
- Added `JFunction#set(JsonObject)` and `JFunction#parameter(String, JsonElement)`, along with primitive value overloads
  - Conditions and functions are surprisingly similar (less so when you consider that conditions are specialized functions...)
  - Speaking of, `JFunction#function(String)` now exists
  - Also renamed `JFunction#add(JCondition)` to `condition` to make it more intuitive
- `JEntry`'s children are now proper `JEntry` instances instead of raw JSON
  - `JEntry#child(String)` has been deprecated as a result
  - Also added `JEntry#function(String)` and `JEntry#condition(String)` for easier adding of simple functions/conditions (like `"minecraft:survives_explosion"`)
- This also fixes the loot table entry's conditions list being output as "condition" rather than "condition*s*" (#20)