### PR TITLE
Add callback to register packs after vanilla 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 # gradle
-gradlew.bat
-gradlew
-.gradle
-build
+.gradle/
+build/
+out/
 
 # idea
 .idea

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '0.6-SNAPSHOT'
+    id 'fabric-loom' version '0.7-SNAPSHOT'
     id 'maven-publish'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '0.4-SNAPSHOT'
+    id 'fabric-loom' version '0.6-SNAPSHOT'
     id 'maven-publish'
 }
 
@@ -10,17 +10,11 @@ archivesBaseName = project.archives_base_name
 version = project.mod_version
 group = project.maven_group
 
-
-minecraft {
-}
-
 dependencies {
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
     mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
-    // https://mvnrepository.com/artifact/org.jetbrains/annotations
-    compileOnly group: 'org.jetbrains', name: 'annotations', version: '19.0.0'
     modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
-    modImplementation include("net.fabricmc.fabric-api:fabric-api-base:${project.fabric_base_version}")
+    modImplementation include(fabricApi.module('fabric-api-base', project.fabric_version))
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,12 +2,11 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=20w29a
-yarn_mappings=20w29a+build.9
-loader_version=+
+minecraft_version=1.16.5
+yarn_mappings=1.16.5+build.9
+loader_version=0.11.3
 #Fabric api
-fabric_version=0.15.0+build.379-1.16
-fabric_base_version=0.1+
+fabric_version=0.34.2+1.16
 # Mod Properties
 mod_version=0.3.11
 maven_group=net.devtech

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Wed Mar 18 11:22:34 CDT 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -82,7 +82,6 @@ esac
 
 CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
 
-
 # Determine the Java command to use to start the JVM.
 if [ -n "$JAVA_HOME" ] ; then
     if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
@@ -126,11 +125,10 @@ if $darwin; then
     GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
 fi
 
-# For Cygwin or MSYS, switch paths to Windows format before running java
-if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin ; then
     APP_HOME=`cygpath --path --mixed "$APP_HOME"`
     CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
-    
     JAVACMD=`cygpath --unix "$JAVACMD"`
 
     # We build the pattern for arguments to be converted via cygpath
@@ -156,19 +154,19 @@ if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
         else
             eval `echo args$i`="\"$arg\""
         fi
-        i=`expr $i + 1`
+        i=$((i+1))
     done
     case $i in
-        0) set -- ;;
-        1) set -- "$args0" ;;
-        2) set -- "$args0" "$args1" ;;
-        3) set -- "$args0" "$args1" "$args2" ;;
-        4) set -- "$args0" "$args1" "$args2" "$args3" ;;
-        5) set -- "$args0" "$args1" "$args2" "$args3" "$args4" ;;
-        6) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" ;;
-        7) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" ;;
-        8) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" ;;
-        9) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" "$args8" ;;
+        (0) set -- ;;
+        (1) set -- "$args0" ;;
+        (2) set -- "$args0" "$args1" ;;
+        (3) set -- "$args0" "$args1" "$args2" ;;
+        (4) set -- "$args0" "$args1" "$args2" "$args3" ;;
+        (5) set -- "$args0" "$args1" "$args2" "$args3" "$args4" ;;
+        (6) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" ;;
+        (7) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" ;;
+        (8) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" ;;
+        (9) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" "$args8" ;;
     esac
 fi
 
@@ -177,9 +175,14 @@ save () {
     for i do printf %s\\n "$i" | sed "s/'/'\\\\''/g;1s/^/'/;\$s/\$/' \\\\/" ; done
     echo " "
 }
-APP_ARGS=`save "$@"`
+APP_ARGS=$(save "$@")
 
 # Collect all arguments for the java command, following the shell quoting and substitution rules
 eval set -- $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS "\"-Dorg.gradle.appname=$APP_BASE_NAME\"" -classpath "\"$CLASSPATH\"" org.gradle.wrapper.GradleWrapperMain "$APP_ARGS"
+
+# by default we should be in the correct project dir, but when run from Finder on Mac, the cwd is wrong
+if [ "$(uname)" = "Darwin" ] && [ "$HOME" = "$PWD" ]; then
+  cd "$(dirname "$0")"
+fi
 
 exec "$JAVACMD" "$@"

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -1,0 +1,100 @@
+@rem
+@rem Copyright 2015 the original author or authors.
+@rem
+@rem Licensed under the Apache License, Version 2.0 (the "License");
+@rem you may not use this file except in compliance with the License.
+@rem You may obtain a copy of the License at
+@rem
+@rem      https://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing, software
+@rem distributed under the License is distributed on an "AS IS" BASIS,
+@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@rem See the License for the specific language governing permissions and
+@rem limitations under the License.
+@rem
+
+@if "%DEBUG%" == "" @echo off
+@rem ##########################################################################
+@rem
+@rem  Gradle startup script for Windows
+@rem
+@rem ##########################################################################
+
+@rem Set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" setlocal
+
+set DIRNAME=%~dp0
+if "%DIRNAME%" == "" set DIRNAME=.
+set APP_BASE_NAME=%~n0
+set APP_HOME=%DIRNAME%
+
+@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m"
+
+@rem Find java.exe
+if defined JAVA_HOME goto findJavaFromJavaHome
+
+set JAVA_EXE=java.exe
+%JAVA_EXE% -version >NUL 2>&1
+if "%ERRORLEVEL%" == "0" goto init
+
+echo.
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:findJavaFromJavaHome
+set JAVA_HOME=%JAVA_HOME:"=%
+set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+
+if exist "%JAVA_EXE%" goto init
+
+echo.
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:init
+@rem Get command-line arguments, handling Windows variants
+
+if not "%OS%" == "Windows_NT" goto win9xME_args
+
+:win9xME_args
+@rem Slurp the command line arguments.
+set CMD_LINE_ARGS=
+set _SKIP=2
+
+:win9xME_args_slurp
+if "x%~1" == "x" goto execute
+
+set CMD_LINE_ARGS=%*
+
+:execute
+@rem Setup the command line
+
+set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
+
+@rem Execute Gradle
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%
+
+:end
+@rem End local scope for the variables with windows NT shell
+if "%ERRORLEVEL%"=="0" goto mainEnd
+
+:fail
+rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
+rem the _cmd.exe /c_ return code!
+if  not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
+exit /b 1
+
+:mainEnd
+if "%OS%"=="Windows_NT" endlocal
+
+:omega

--- a/src/main/java/net/devtech/arrp/api/RRPCallback.java
+++ b/src/main/java/net/devtech/arrp/api/RRPCallback.java
@@ -28,7 +28,7 @@ public interface RRPCallback {
 	 * @deprecated use {@link #BEFORE_VANILLA} instead
 	 */
 	@Deprecated
-	Event<RRPCallback> EVENT = AFTER_VANILLA;
+	Event<RRPCallback> EVENT = BEFORE_VANILLA;
 
 	/**
 	 * you can only add resource packs to this list, you may not remove them

--- a/src/main/java/net/devtech/arrp/api/RRPCallback.java
+++ b/src/main/java/net/devtech/arrp/api/RRPCallback.java
@@ -25,7 +25,8 @@ public interface RRPCallback {
 	});
 
 	/**
-	 * @deprecated use {@link #BEFORE_VANILLA} instead
+	 * @deprecated unintuitive name
+	 * @see #BEFORE_VANILLA
 	 */
 	@Deprecated
 	Event<RRPCallback> EVENT = BEFORE_VANILLA;

--- a/src/main/java/net/devtech/arrp/api/RRPCallback.java
+++ b/src/main/java/net/devtech/arrp/api/RRPCallback.java
@@ -10,12 +10,25 @@ import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 
 public interface RRPCallback {
-	Event<RRPCallback> EVENT = EventFactory.createArrayBacked(RRPCallback.class, r -> rs -> {
+	Event<RRPCallback> BEFORE_VANILLA = EventFactory.createArrayBacked(RRPCallback.class, r -> rs -> {
 		IrremovableList<ResourcePack> packs = new IrremovableList<>(rs, $ -> {});
 		for (RRPCallback callback : r) {
 			callback.insert(packs);
 		}
 	});
+
+	Event<RRPCallback> AFTER_VANILLA = EventFactory.createArrayBacked(RRPCallback.class, r -> rs -> {
+		IrremovableList<ResourcePack> packs = new IrremovableList<>(rs, $ -> {});
+		for (RRPCallback callback : r) {
+			callback.insert(packs);
+		}
+	});
+
+	/**
+	 * @deprecated use {@link #BEFORE_VANILLA} instead
+	 */
+	@Deprecated
+	Event<RRPCallback> EVENT = AFTER_VANILLA;
 
 	/**
 	 * you can only add resource packs to this list, you may not remove them

--- a/src/main/java/net/devtech/arrp/mixin/ReloadableResourceManagerImplMixin.java
+++ b/src/main/java/net/devtech/arrp/mixin/ReloadableResourceManagerImplMixin.java
@@ -30,9 +30,22 @@ public abstract class ReloadableResourceManagerImplMixin {
 			CompletableFuture<Unit> initialStage,
 			List<ResourcePack> packs,
 			CallbackInfoReturnable<ResourceReloadMonitor> cir) {
-		LOGGER.info("ARRP register");
+		LOGGER.info("ARRP register - before vanilla");
 		List<ResourcePack> pack = new ArrayList<>();
-		RRPCallback.EVENT.invoker().insert(pack);
+		RRPCallback.BEFORE_VANILLA.invoker().insert(pack);
+		pack.forEach(this::addPack);
+	}
+
+	@Inject (method = "beginMonitoredReload",
+			at = @At(value = "RETURN", shift = At.Shift.BEFORE))
+	private void registerARRPsAfter(Executor prepareExecutor,
+			Executor applyExecutor,
+			CompletableFuture<Unit> initialStage,
+			List<ResourcePack> packs,
+			CallbackInfoReturnable<ResourceReloadMonitor> cir) {
+		LOGGER.info("ARRP register - after vanilla");
+		List<ResourcePack> pack = new ArrayList<>();
+		RRPCallback.AFTER_VANILLA.invoker().insert(pack);
 		pack.forEach(this::addPack);
 	}
 


### PR DESCRIPTION
This allows overriding vanilla resources!

The old singular `EVENT` callback has been renamed to `BEFORE_VANILLA`, to be more descriptive (old name still works, of course!)

(I also took the liberty of updating everything and adding `gradlew.bat` for us Windows users)