### PR TITLE
Make mod appear as library in Mod Menu

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,5 +24,10 @@
   "depends": {
     "fabricloader": ">=0.8.8+build.202",
     "minecraft": ">=1.16.1"
+  },
+  "custom": {
+    "modmenu": {
+      "badges": [ "library" ]
+    }  
   }
 }


### PR DESCRIPTION
This would add the Mod Menu library badge to ARRP according to Mod Menu's documentation (https://github.com/TerraformersMC/ModMenu/wiki/API#Badges)

Currently appears as:
<img src="https://user-images.githubusercontent.com/38622942/120122525-a1049d00-c1a9-11eb-86d0-af37d8d54612.jpg" width=500>

With the small change will appear as:
<img src="https://user-images.githubusercontent.com/38622942/120122534-ae218c00-c1a9-11eb-9e95-ccc3620be5ec.jpg" width=500>

While only a minor change, it will help keep users mod lists cleaner and improve search filtering.

