### PR TITLE
Add empty constructor to JCondition

### DIFF
--- a/src/main/java/net/devtech/arrp/json/loot/JCondition.java
+++ b/src/main/java/net/devtech/arrp/json/loot/JCondition.java
@@ -26,6 +26,9 @@ public class JCondition implements Cloneable {
 			this.condition(condition);
 		}
 	}
+	
+	public JCondition(String condition) {
+	}
 
 	public JCondition condition(String condition) {
 		this.parameters.addProperty("condition", condition);

--- a/src/main/java/net/devtech/arrp/json/loot/JCondition.java
+++ b/src/main/java/net/devtech/arrp/json/loot/JCondition.java
@@ -27,7 +27,7 @@ public class JCondition implements Cloneable {
 		}
 	}
 	
-	public JCondition(String condition) {
+	public JCondition() {
 	}
 
 	public JCondition condition(String condition) {


### PR DESCRIPTION
For use in edge cases such as the crossbow item model, which requires using `"pulling": <float>` rather than `"condition": <string>`