### PR TITLE
Use own logger in mixin instead of shadowing, fixing 22w03a

### DIFF
--- a/src/main/java/net/devtech/arrp/mixin/ReloadableResourceManagerImplMixin.java
+++ b/src/main/java/net/devtech/arrp/mixin/ReloadableResourceManagerImplMixin.java
@@ -6,6 +6,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
 import net.devtech.arrp.api.RRPCallback;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -21,7 +22,7 @@ import net.minecraft.util.Unit;
 
 @Mixin (ReloadableResourceManagerImpl.class)
 public abstract class ReloadableResourceManagerImplMixin {
-	@Shadow @Final private static Logger LOGGER;
+	private static final Logger LOGGER = LogManager.getLogger("ARRP");
 
 	@Inject (method = "beginMonitoredReload",
 			at = @At (value = "INVOKE", target = "Ljava/util/List;iterator()Ljava/util/Iterator;"))


### PR DESCRIPTION
With 22w03a's switch to slf4j, the shadowed field with that signature no longer exists. This means that ARRP crashes with mixin failures on 22w03a. This changes the mixin to use its own logger instead of relying on the shadowed one, so that old compat can be kept whilst fixing 22w03a.

Only tested against 22w03a, no reason this won't work on older versions.