### PR TITLE
add callback event for after mod resources but before user resources

### DIFF
--- a/src/main/java/net/devtech/arrp/api/RRPCallback.java
+++ b/src/main/java/net/devtech/arrp/api/RRPCallback.java
@@ -29,6 +29,12 @@ public interface RRPCallback {
 	Event<RRPCallback> BETWEEN_VANILLA_AND_MODS = EventFactory.createArrayBacked(RRPCallback.class, CALLBACK_FUNCTION);
 
 	/**
+	 * Register your resource pack between mod resources and user resources. This is similar to the BEFORE_USER event,
+	 * but is always enabled and not visible in the resource pack selection screen.
+	 */
+	Event<RRPCallback> BETWEEN_MODS_AND_USER = EventFactory.createArrayBacked(RRPCallback.class, CALLBACK_FUNCTION);
+
+	/**
 	 * Register your resource pack at a higher priority than minecraft and mod resources, but lower priority than user resources.
 	 */
 	Event<RRPCallback> BEFORE_USER = EventFactory.createArrayBacked(RRPCallback.class, CALLBACK_FUNCTION);

--- a/src/main/java/net/devtech/arrp/api/SidedRRPCallback.java
+++ b/src/main/java/net/devtech/arrp/api/SidedRRPCallback.java
@@ -38,6 +38,13 @@ public interface SidedRRPCallback {
 	Event<SidedRRPCallback> BETWEEN_VANILLA_AND_MODS = EventFactory.createArrayBacked(SidedRRPCallback.class, CALLBACK_FUNCTION);
 
 	/**
+	 * Register your resource pack between mod resources and user resources.
+	 * <p>
+	 * If you want to override vanilla and mod resources but allow resource packs to override it
+	 */
+	Event<SidedRRPCallback> BETWEEN_MODS_AND_USER = EventFactory.createArrayBacked(SidedRRPCallback.class, CALLBACK_FUNCTION);
+
+	/**
 	 * Register your resource pack at a lower priority than minecraft and mod resources. This is actually done by
 	 * passing a view of the resource pack list, such that List#add will add to the end of the list, after default
 	 * resource packs.
@@ -54,6 +61,7 @@ public interface SidedRRPCallback {
 	static Void INIT_ = Util.make(() -> {
 		BEFORE_VANILLA.register((type, resources) -> RRPCallback.BEFORE_VANILLA.invoker().insert(resources));
 		BETWEEN_VANILLA_AND_MODS.register((type, resources) -> RRPCallback.BETWEEN_VANILLA_AND_MODS.invoker().insert(resources));
+		BETWEEN_MODS_AND_USER.register((type, resources) -> RRPCallback.BETWEEN_MODS_AND_USER.invoker().insert(resources));
 		AFTER_VANILLA.register((type, resources) -> RRPCallback.AFTER_VANILLA.invoker().insert(resources));
 		return null;
 	});

--- a/src/main/java/net/devtech/arrp/mixin/LifecycledResourceManagerImplMixin.java
+++ b/src/main/java/net/devtech/arrp/mixin/LifecycledResourceManagerImplMixin.java
@@ -39,6 +39,8 @@ public abstract class LifecycledResourceManagerImplMixin {
 		if (optionalInt.isPresent()) {
 			ARRP_LOGGER.info("ARRP register - between vanilla and mods");
 			SidedRRPCallback.BETWEEN_VANILLA_AND_MODS.invoker().insert(type, copy.subList(0, optionalInt.getAsInt()));
+			ARRP_LOGGER.info("ARRP register - between mods and user");
+			SidedRRPCallback.BETWEEN_MODS_AND_USER.invoker().insert(type, copy.subList(0, optionalInt.getAsInt()+1));
 		}
 		
 		ARRP_LOGGER.info("ARRP register - after vanilla");

--- a/src/main/java/net/devtech/arrp/mixin/LifecycledResourceManagerImplMixin.java
+++ b/src/main/java/net/devtech/arrp/mixin/LifecycledResourceManagerImplMixin.java
@@ -38,9 +38,11 @@ public abstract class LifecycledResourceManagerImplMixin {
 
 		if (optionalInt.isPresent()) {
 			ARRP_LOGGER.info("ARRP register - between vanilla and mods");
+			int initialCopyLength = copy.size();
 			SidedRRPCallback.BETWEEN_VANILLA_AND_MODS.invoker().insert(type, copy.subList(0, optionalInt.getAsInt()));
 			ARRP_LOGGER.info("ARRP register - between mods and user");
-			SidedRRPCallback.BETWEEN_MODS_AND_USER.invoker().insert(type, copy.subList(0, optionalInt.getAsInt()+1));
+			int finalCopyLength = copy.size();
+			SidedRRPCallback.BETWEEN_MODS_AND_USER.invoker().insert(type, copy.subList(0, optionalInt.getAsInt()+1+(finalCopyLength-initialCopyLength)));
 		}
 		
 		ARRP_LOGGER.info("ARRP register - after vanilla");


### PR DESCRIPTION
This event is very similar to the `USER_RESOURCES` callback, but is automatically enabled (and cannot be disabled) and is not visible in the resource pack selection screen, similar to the `BEFORE_VANILLA`, `BETWEEN_VANILLA_AND_MODS`, and `AFTER_VANILLA` events.